### PR TITLE
Adds support for building darwin-compatible binaries

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -10,22 +10,31 @@
 #	  clean:			  		removes build artifacts (aka binaries)
 #	  clean-all:	  		cleans, then removes the artifact for build/container
 
-.DEFAULT_GOAL := build
+SHELL := /bin/bash
 
 # some terminal color escape codes
-LIGHT_GREEN=\033[1;32m
-NC=\033[0m  # No Color
+LIGHT_GREEN := $(shell echo -e "\033[1;32m")
+NC := $(shell echo -e "\033[0m") # No Color
 
 # obtains the latest git SHA for the current repo, which is used to tag docker
 # images and set properties in the golang binaries
 GIT_SHA:= $(shell git rev-parse HEAD 2>/dev/null | cut -c 1-7)
 
+# Platform/arch specific crud:
+# - On linux, run the container with the current uid, so files produced from
+#   within the container are owned by the current user, rather than root.
+# - On OSX, don't do anything with the container user, and let boot2docker manage
+#   permissions on the /Users mount that it sets up
+# - cross-compile (if necessary) in the container, but keep the same binary name
+DOCKER_USER := $(shell if [[ "$$OSTYPE" != "darwin"* ]]; then USER_ARG="--user=`id -u`"; fi; echo "$$USER_ARG")
+GOOS   := $(shell if [[ "$$OSTYPE" == "darwin"* ]]; then echo "darwin"; else echo "linux"; fi)
+GOARCH := $(shell if [[ `uname -a` == *"x86_64"* ]]; then echo "amd64"; else echo "386"; fi)
+
 # the "root" pkg contained in this project.  If the project contains multiple
 # binaries, each binary's main pkg will be in a subdir of SRC_ROOT
 SRC_ROOT={{.Repository}}/{{.Namespace}}/{{.Project}}/
 
-# the uid of the current user on the host machine
-HOST_UID:= $(shell id -u)
+.DEFAULT_GOAL := build
 
 # Builds the docker image that we'll use to compile all subsequent golang code
 # touch: http://www.gnu.org/software/make/manual/make.html#Empty-Targets
@@ -45,8 +54,8 @@ godep: build/container
 	@docker run --rm \
 		-v "$$PWD":"/go/src/${SRC_ROOT}" \
 		-w "/go/src/${SRC_ROOT}" \
-		-u ${HOST_UID} \
-		-t boilerplate/compile \
+		${DOCKER_USER} \
+	  -t boilerplate/compile \
 		godep save
 .PHONY: godep
 
@@ -54,13 +63,16 @@ godep: build/container
 
 # builds the binary in a Docker container and copies it to a volume mount (/output/)
 {{.Project}}: $({{ToUpper .Project}}_SRCS) build/container
-	@echo "${LIGHT_GREEN}building binary for {{.Project}}...${NC}"
+	@echo "${LIGHT_GREEN}building ${GOOS}-compatible ${GOARCH} binary for {{.Project}}...${NC}"
 	@docker run --rm \
 		-v "$$PWD":"/go/src/${SRC_ROOT}" \
 		-w "/go/src/${SRC_ROOT}" \
 		-v "$${PWD}/":/output \
+		${DOCKER_USER} \
+		-e "GOOS=${GOOS}" \
+	  -e "GOARCH=${GOARCH}" \
+		-e "BINARY={{.Project}}" \
 		-e "GIT_SHA=${GIT_SHA}" \
-    -e "USER=${HOST_UID}" \
 		-t boilerplate/compile
 
 build: {{.Project}}
@@ -88,8 +100,18 @@ lint: build/container
 		golint ./...
 .PHONY: lint
 
-# Build docker images and tags them with the latest git SHA
-dockerize: install
+# Build a linux-compatible binary and a docker image that uses the binary as it's entrypoint
+dockerize:
+	@echo "${LIGHT_GREEN}building {{.Project}} binary for inclusion in Docker image...${NC}"
+	@docker run --rm \
+		-v "$$PWD":"/go/src/${SRC_ROOT}" \
+		-w "/go/src/${SRC_ROOT}" \
+		-v "$${PWD}/":/output \
+		${DOCKER_USER} \
+		-e "BINARY={{.Project}}" \
+		-e "GIT_SHA=${GIT_SHA}" \
+		-t boilerplate/compile
+
 	@echo "${LIGHT_GREEN} building Docker image '{{.Namespace}}/{{.Project}}'...${NC}"
 	@docker build --no-cache \
 		-f "Dockerfile" \

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Boilerplate makes/enforces several assumptions about the structure and conventio
 * `git`
 * `make`
 * `go`
-* `Docker`
+* `Docker` (or `boot2docker` for OSX users)
 
 ## Quick Start
 
@@ -94,4 +94,4 @@ See the generated `Makefile` in your `boilerplate`-created project for more deta
 
 ## Limitations and known issues
 
-Boilerplate produces `x86_64`-compatible Linux binaries, and has not been used on OSX or Windows.
+Boilerplate was developed on, and is used daily on, various Linux OSes.  It has been known to work on OSX with `boot2docker`. It has not been used on Windows. (pull requests welcome!)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.4.2
+FROM golang:1.4.2-cross
 MAINTAINER Core Engineering <core@zulily.com>
 
 RUN go get github.com/tools/godep
@@ -13,4 +13,4 @@ ENV GOBIN /output
 ENV GIT_SHA unknown
 
 # Invokes a shell explicitly, to get param expansion of $GIT_SHA and $USER
-CMD ["sh", "-c", "godep go install -a -tags netgo -ldflags -s -ldflags \"-X main.BuildSHA ${GIT_SHA}\" && chown -R ${USER}:${USER} /output"]
+CMD ["sh", "-c", "godep go build -o ${BINARY} -a -tags netgo -ldflags -s -ldflags \"-X main.BuildSHA ${GIT_SHA}\" "]


### PR DESCRIPTION
boilerplate/compile Docker image is now based off of the cross-compilation enabled `golang` Docker image (which is unfortunately huuuuuge)

Makefile changes:
- 'dockerize' target builds a linux-compatible binary for inclusion in Docker image
- 'build' target builds a darwin/linux binary, depending on the host OS
- binary name is specified explicitly when building, to prevent paths from changing when building on Linux/OSX
